### PR TITLE
Fix for force an inventory not working

### DIFF
--- a/Windows/updatengine-client.py
+++ b/Windows/updatengine-client.py
@@ -22,9 +22,11 @@
 ###############################################################################
 
 
+import os
 import optparse
 import time
 import logging
+from urlparse import urlparse
 from ueinventory import ueinventory
 from uecommunication import uecommunication
 from uedownload import uedownload
@@ -38,7 +40,7 @@ def wait(minutes, passphrase):
     Host = ''
     Port = 2010
     Sock.bind((Host,Port))
-    Sock.listen(1)
+    Sock.listen(3)
     limit = datetime.now()+timedelta(minutes=minutes)
     print "wait for connexion with passphrase %s or %s" % (passphrase, limit)
     try:
@@ -47,6 +49,7 @@ def wait(minutes, passphrase):
             RequeteDuClient = client.recv(255)
             print RequeteDuClient
             if RequeteDuClient == passphrase:
+                client.close()
                 Sock.close()
                 return
     except socket.timeout:


### PR DESCRIPTION
This fixes forced inventory asked by UE server not working.
Moved import to head and add 2 more client to the socket listen call (for some reason it's working with >= 2 but not with only 1 client allowed).
Add client close after passphrase received.
